### PR TITLE
Add removal to frontend to support finalizers 

### DIFF
--- a/graphula-core/README.lhs
+++ b/graphula-core/README.lhs
@@ -21,7 +21,7 @@ import Test.Hspec
 
 main :: IO ()
 main = hspec $
-  describe "graphula-core" $ do
+  describe "graphula-core" . parallel $ do
     it "generates and links arbitrary graphs of data" simpleSpec
     it "allows logging and replaying graphs" loggingAndReplaySpec
     it "attempts to retry node generation on insertion failure" insertionFailureSpec

--- a/graphula-core/README.lhs
+++ b/graphula-core/README.lhs
@@ -146,6 +146,8 @@ graphIdentity :: Frontend NoConstraint Identity (IO r) -> IO r
 graphIdentity f = case f of
   Insert n next ->
     next $ Just $ Identity n
+  Remove _ next ->
+    next
 ```
 
 We can create other front-ends. For example, a front-end that always fails to insert.

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -140,7 +140,7 @@ runGraphulaIdempotentLogged
   -> Graph Arbitrary ToJSON nodeConstraint entity m a -> m a
 runGraphulaIdempotentLogged frontend graph = do
   graphLog <- liftIO $ newIORef ""
-  catch (go graphLog) (logFail graphLog)
+  catch (go graphLog) (logFailTemp graphLog)
     where
       go graphLog = runGraphulaIdempotent' (backendArbitraryLogged graphLog) frontend graph
 

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -217,10 +217,10 @@ finalizerFrontend finalizersRef f = case f of
   Insert n next -> do
     mEnt <- liftF $ Insert n id
     for_ mEnt $ \ent ->
-      liftIO $ modifyIORef' finalizersRef ((>>) (liftF $ Remove ent ()))
+      liftIO $ modifyIORef' finalizersRef (remove ent >>)
     lift $ next mEnt
   Remove ent next -> do
-    liftF $ Remove ent ()
+    remove ent
     lift next
 
 backendArbitrary :: (MonadThrow m, MonadIO m) => Backend Arbitrary NoConstraint (m b) -> m b
@@ -314,6 +314,9 @@ deriving instance Functor (Frontend nodeConstraint entity)
 
 insert :: (Monad m, nodeConstraint a) => a -> Graph generate log nodeConstraint entity m (Maybe (entity a))
 insert n = liftRight $ liftF (Insert n id)
+
+remove :: (Monad m, nodeConstraint a) => entity a -> FreeT (Frontend nodeConstraint entity) m ()
+remove n = liftF (Remove n ())
 
 
 data Backend (generate :: * -> Constraint) (log :: * -> Constraint) next where

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -140,7 +140,7 @@ runGraphulaIdempotentLogged
   -> Graph Arbitrary ToJSON nodeConstraint entity m a -> m a
 runGraphulaIdempotentLogged frontend graph = do
   graphLog <- liftIO $ newIORef ""
-  catch (go graphLog) (logFailTemp graphLog)
+  go graphLog `catch` logFailTemp graphLog
   where
     go graphLog = runGraphulaIdempotentUsing (backendArbitraryLogged graphLog) frontend graph
 

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -123,12 +123,17 @@ runGraphula
   -> m a
 runGraphula = runGraphulaUsing backendArbitrary
 
+-- | An extension of 'runGraphula' that produces finalizers to remove graph nodes
+-- on error or completion. An idempotent 'Graph' produces no data outside of its
+-- own closure.
 runGraphulaIdempotent
   :: (MonadIO m, MonadCatch m)
   => (Frontend nodeConstraint entity (m a) -> m a)
   -> Graph Arbitrary NoConstraint nodeConstraint entity m a -> m a
 runGraphulaIdempotent = runGraphulaIdempotent' backendArbitrary
 
+-- | An extension of 'runGraphulaIdemptotent' that produces replayable logs, like
+-- 'runGraphulaLogged'.
 runGraphulaIdempotentLogged
   :: (MonadIO m, MonadCatch m)
   => (Frontend nodeConstraint entity (m a) -> m a)
@@ -203,7 +208,6 @@ runGraphulaReplay replayFile frontend f = do
   replayLog <- liftIO $ newIORef =<< (lines <$> readFile replayFile)
   runGraphulaUsing (backendReplay replayLog) frontend f
     `catch` rethrowHUnitReplay replayFile
-
 
 
 finalizerFrontend

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -141,8 +141,8 @@ runGraphulaIdempotentLogged
 runGraphulaIdempotentLogged frontend graph = do
   graphLog <- liftIO $ newIORef ""
   catch (go graphLog) (logFailTemp graphLog)
-    where
-      go graphLog = runGraphulaIdempotentUsing (backendArbitraryLogged graphLog) frontend graph
+  where
+    go graphLog = runGraphulaIdempotentUsing (backendArbitraryLogged graphLog) frontend graph
 
 runGraphulaIdempotentUsing
   :: (MonadIO m, MonadCatch m)

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -156,9 +156,7 @@ runGraphulaIdempotentUsing backend frontend f =
     rollback finalizersRef $ pure x
   where
     interpret finalizersRef =
-      flip iterT f $ \case
-        InR r -> iterT frontend $ finalizerFrontend finalizersRef r
-        InL l -> backend l
+      runGraphulaUsing backend (iterT frontend . finalizerFrontend finalizersRef) f
     rollback finalizersRef x = do
       finalizers <- liftIO $ readIORef finalizersRef
       iterT frontend (finalizers >> x)

--- a/graphula-persistent/README.lhs
+++ b/graphula-persistent/README.lhs
@@ -142,6 +142,6 @@ migrateTestDB = runMigration migrateAll
 runTestDB :: ReaderT SqlBackend (NoLoggingT (ResourceT IO)) a -> IO a
 runTestDB = runSqlite ":test:"
 
-withGraph :: Graph Arbitrary NoConstraint (PersistRecord SqlBackend) Entity IO b -> IO b
-withGraph = runGraphulaIdempotent (persistGraph runTestDB)
+withGraph :: Graph Arbitrary ToJSON (PersistRecord SqlBackend) Entity IO b -> IO b
+withGraph = runGraphulaIdempotentLogged (persistGraph runTestDB)
 ```

--- a/graphula-persistent/README.lhs
+++ b/graphula-persistent/README.lhs
@@ -59,7 +59,7 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"]
 main :: IO ()
 main =
   hspec $
-  beforeAll (runTestDB $ migrateTestDB *> truncateTestDB) $
+  beforeAll (runTestDB $ migrateTestDB) $
   describe "graphula-persistent" $ do
 
     let makeSimpleGraph = do
@@ -139,16 +139,9 @@ instance FromJSON DT
 migrateTestDB :: ReaderT SqlBackend (NoLoggingT (ResourceT IO)) ()
 migrateTestDB = runMigration migrateAll
 
-truncateTestDB :: ReaderT SqlBackend (NoLoggingT (ResourceT IO)) ()
-truncateTestDB = do
-  deleteWhere ([] :: [Filter DT])
-  deleteWhere ([] :: [Filter CT])
-  deleteWhere ([] :: [Filter BT])
-  deleteWhere ([] :: [Filter AT])
-
 runTestDB :: ReaderT SqlBackend (NoLoggingT (ResourceT IO)) a -> IO a
 runTestDB = runSqlite ":test:"
 
-withGraph :: Graph Arbitrary ToJSON (PersistRecord SqlBackend) Entity IO b -> IO b
-withGraph = runGraphulaLogged (persistGraph runTestDB)
+withGraph :: Graph Arbitrary NoConstraint (PersistRecord SqlBackend) Entity IO b -> IO b
+withGraph = runGraphulaIdempotent (persistGraph runTestDB)
 ```

--- a/graphula-persistent/src/Graphula/Persist.hs
+++ b/graphula-persistent/src/Graphula/Persist.hs
@@ -28,6 +28,9 @@ persistGraph runDB = \case
         Nothing -> pure Nothing
         Just key' -> getEntity key'
     next x
+  Remove n next -> do
+    runDB $ delete $ entityKey n
+    next
 
 class (PersistEntity a, PersistEntityBackend a ~ SqlBackend, PersistStoreWrite backend, PersistUniqueWrite backend) => PersistRecord backend a where
 

--- a/graphula-persistent/src/Graphula/Persist.hs
+++ b/graphula-persistent/src/Graphula/Persist.hs
@@ -29,7 +29,7 @@ persistGraph runDB = \case
         Just key' -> getEntity key'
     next x
   Remove n next -> do
-    runDB $ delete $ entityKey n
+    runDB . delete $ entityKey n
     next
 
 class (PersistEntity a, PersistEntityBackend a ~ SqlBackend, PersistStoreWrite backend, PersistUniqueWrite backend) => PersistRecord backend a where


### PR DESCRIPTION
Finalizers allow graphula to unwind the graph upon completion (or
failure). This allows idempotent tests to clean up after themselves. In
a more complicated database setting, this would avoid the need to
truncate many tables and repopulate any preloaded data.