### PR TITLE
Add generic HasDependencies instance for data types with no constructors

### DIFF
--- a/graphula-core/README.lhs
+++ b/graphula-core/README.lhs
@@ -157,6 +157,8 @@ graphInsertFails :: Monad m => Frontend NoConstraint Identity (m r) -> m r
 graphInsertFails f = case f of
   Insert _ next ->
     next $ Nothing
+  Remove _ next ->
+    next
 
 insertionFailureSpec :: IO ()
 insertionFailureSpec = do

--- a/graphula-core/src/Graphula/Internal.hs
+++ b/graphula-core/src/Graphula/Internal.hs
@@ -51,9 +51,20 @@ class GHasDependenciesRecursive fieldsProxy node deps where
   genericDependsOnRecursive :: fieldsProxy -> node -> deps -> node
 
 -- This instance head only matches EoT representations of
--- datatypes with no constructors. Ignore dependencies.
-instance GHasDependencies (Proxy nodeTy) (Proxy depsTy) Void deps where
+-- datatypes with no constructors and no dependencies
+instance {-# OVERLAPPING #-} GHasDependencies (Proxy nodeTy) (Proxy depsTy) Void (Either () Void) where
   genericDependsOn _ _ node _ = node
+
+-- This instance warns the user if they give dependencies
+-- to a datatype with no constructors
+instance
+  {-# OVERLAPPABLE #-}
+  ( TypeError
+    ( 'Text "A datatype with no constructors can't use the dependencies in" ':$$:
+      DependenciesTypeInstance nodeTy depsTy
+    )
+  ) => GHasDependencies (Proxy nodeTy) (Proxy depsTy) Void (Either deps rest) where
+    genericDependsOn _ _ _ _ = error "Impossible"
 
 -- This instance head only matches EoT representations of
 -- datatypes with a single constructor
@@ -92,6 +103,15 @@ instance
       DependenciesTypeInstance nodeTy depsTy
     )
   ) => GHasDependencies (Proxy nodeTy) (Proxy depsTy) (Either left1 (Either right1 rest1)) (Either left2 (Either right2 rest2)) where
+    genericDependsOn _ _ _ _ = error "Impossible"
+
+-- Don't let the user specify `Void` as a dependency
+instance
+  ( TypeError
+    ( 'Text "Use ‘()’ instead of ‘Void’ for datatypes with no dependencies in" ':$$:
+      DependenciesTypeInstance nodeTy depsTy
+    )
+  ) => GHasDependencies (Proxy nodeTy) (Proxy depsTy) node Void where
     genericDependsOn _ _ _ _ = error "Impossible"
 
 instance

--- a/graphula-core/src/Graphula/Internal.hs
+++ b/graphula-core/src/Graphula/Internal.hs
@@ -51,6 +51,11 @@ class GHasDependenciesRecursive fieldsProxy node deps where
   genericDependsOnRecursive :: fieldsProxy -> node -> deps -> node
 
 -- This instance head only matches EoT representations of
+-- datatypes with no constructors. Ignore dependencies.
+instance GHasDependencies (Proxy nodeTy) (Proxy depsTy) Void deps where
+  genericDependsOn _ _ node _ = node
+
+-- This instance head only matches EoT representations of
 -- datatypes with a single constructor
 instance
   ( FindMatches nodeTy depsTy node deps ~ fields


### PR DESCRIPTION
I'm not sure how useful this is, but the nullary constructor issue got me thinking about empty data decls. This change allows the following

```haskell
data Nope deriving Generic

instance HasDependencies Nope
```

Technically, it also allows nonsense like:

```haskell
data Nope deriving Generic

instance HasDependencies Nope where
  type Dependencies Nope = (Int, Bool)
```

but we just ignore the dependencies. There's a probably a few ways to warn the user about doing that, but the one I figured out requires overlapping instances. I doubt this is an important enough use-case to worry about that.