### PR TITLE
Switch graphula from an initial algebra to a final tag-less representation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 :test:
 *.graphula
 *.tix
+*.prof

--- a/graphula-core/README.lhs
+++ b/graphula-core/README.lhs
@@ -15,6 +15,7 @@ import Data.Typeable
 import Data.Functor.Identity (Identity(..))
 import Control.Monad.IO.Class
 import Graphula
+import Graphula.Free
 import GHC.Generics (Generic)
 import Test.QuickCheck
 import Test.Hspec

--- a/graphula-core/README.lhs
+++ b/graphula-core/README.lhs
@@ -8,14 +8,15 @@ Graphula is a simple interface for generating data and linking its dependencies.
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Main where
 
 import Data.Aeson
 import Data.Typeable
 import Data.Functor.Identity (Identity(..))
+import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Graphula
-import Graphula.Free
 import GHC.Generics (Generic)
 import Test.QuickCheck
 import Test.Hspec
@@ -32,7 +33,7 @@ main = hspec $
 ```haskell
 simpleSpec :: IO ()
 simpleSpec =
-  runGraphula graphIdentity $ do
+  runGraphulaIdentity . runGraphulaT $ do
     -- Declare the graph at the term level
     Identity a <- node @A
     Identity b <- nodeWith @B (only a)
@@ -125,11 +126,11 @@ loggingAndReplaySpec = do
   let
     logFile = "test.graphula"
     -- We'd typically use `runGraphulaLogged` which utilizes a temp file.
-    failingGraph = runGraphulaLoggedWithFile logFile graphIdentity $ do
+    failingGraph = runGraphulaIdentity . runGraphulaLoggedWithFileT logFile $ do
       Identity a <- nodeEdit @A $ \n ->
         n {aa = "success"}
       liftIO $ aa a `shouldBe` "failed"
-    replayGraph = runGraphulaReplay logFile graphIdentity $ do
+    replayGraph = runGraphulaIdentity . runGraphulaReplayT logFile $ do
       Identity a <- node @A
       liftIO $ aa a `shouldBe` "success"
 
@@ -143,28 +144,32 @@ loggingAndReplaySpec = do
 `runGraphula` requires you to provide a front-end. This carries the instructions for evaluating a graph. Our simple `Frontend` is not constraining types and it is wrapping insert results in `Identity`. [`Graphula.Persist`](https://github.com/frontrowed/graphula/tree/master/graphula-persistent) is an example of a more complex frontend utilizing `Database.Persist`.
 
 ```haskell
-graphIdentity :: Frontend NoConstraint Identity (IO r) -> IO r
-graphIdentity f = case f of
-  Insert n next ->
-    next $ Just $ Identity n
-  Remove _ next ->
-    next
+newtype GraphulaIdentity a = GraphulaIdentity { runGraphulaIdentity :: IO a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch, MonadMask)
+
+instance MonadGraphulaFrontend GraphulaIdentity where
+  type NodeConstraint GraphulaIdentity = NoConstraint
+  type Node GraphulaIdentity = Identity
+  insert = pure . Just . Identity
+  remove = const (pure ())
 ```
 
 We can create other front-ends. For example, a front-end that always fails to insert.
 
 ```haskell
-graphInsertFails :: Monad m => Frontend NoConstraint Identity (m r) -> m r
-graphInsertFails f = case f of
-  Insert _ next ->
-    next $ Nothing
-  Remove _ next ->
-    next
+newtype GraphulaFail a = GraphulaFail { runGraphulaFail :: IO a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch, MonadMask)
+
+instance MonadGraphulaFrontend GraphulaFail where
+  type NodeConstraint GraphulaFail = NoConstraint
+  type Node GraphulaFail = Identity
+  insert _ = pure $ Nothing
+  remove = const (pure ())
 
 insertionFailureSpec :: IO ()
 insertionFailureSpec = do
   let
-    failingGraph = runGraphula graphInsertFails $ do
+    failingGraph =  runGraphulaFail . runGraphulaT $ do
       Identity _ <- node @A
       pure ()
   failingGraph

--- a/graphula-core/bench/Main.hs
+++ b/graphula-core/bench/Main.hs
@@ -56,7 +56,7 @@ instance MonadGraphulaFrontend TagglessGraphula where
   type NodeConstraint TagglessGraphula = NoConstraint
   type Entity TagglessGraphula = Identity
   insert = pure . Just . Identity
-  removeM = const (pure ())
+  remove = const (pure ())
 
 instance MonadGraphulaBackend TagglessGraphula where
   type Logging TagglessGraphula = NoConstraint

--- a/graphula-core/bench/Main.hs
+++ b/graphula-core/bench/Main.hs
@@ -55,7 +55,7 @@ newtype TagglessGraphula a = TagglessGraphula { runTagglessGraphula :: IO a }
 
 instance MonadGraphulaFrontend TagglessGraphula where
   type NodeConstraint TagglessGraphula = NoConstraint
-  type Entity TagglessGraphula = Identity
+  type Node TagglessGraphula = Identity
   insert = pure . Just . Identity
   remove = const (pure ())
 

--- a/graphula-core/bench/Main.hs
+++ b/graphula-core/bench/Main.hs
@@ -6,6 +6,7 @@ module Main where
 
 import Criterion.Main
 import Graphula
+import qualified Graphula.Free as Free
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck (generate)
 import Control.Monad.Trans
@@ -39,15 +40,15 @@ instance Arbitrary A where
 
 instance HasDependencies A
 
-graphIdentity :: Frontend NoConstraint Identity (IO r) -> IO r
+graphIdentity :: Free.Frontend NoConstraint Identity (IO r) -> IO r
 graphIdentity f = case f of
-  Insert n next ->
+  Free.Insert n next ->
     next $ Just $ Identity n
-  Remove _ next ->
+  Free.Remove _ next ->
     next
 
 replicateNodeInitial :: Int -> IO ()
-replicateNodeInitial i = void . runGraphula graphIdentity . replicateM i $ node @A
+replicateNodeInitial i = void . Free.runGraphula graphIdentity . replicateM i $ node @A
 
 newtype TagglessGraphula a = TagglessGraphula { runTagglessGraphula :: IO a }
   deriving (Functor, Applicative, Monad, MonadIO, MonadThrow)

--- a/graphula-core/bench/Main.hs
+++ b/graphula-core/bench/Main.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+module Main where
+
+import Criterion.Main
+import Graphula
+import Test.QuickCheck.Arbitrary
+import Test.QuickCheck (generate)
+import Control.Monad.Trans
+import Control.Monad.Catch
+import Data.Functor.Identity
+import Control.Monad (void, replicateM)
+import GHC.Generics
+
+main :: IO ()
+main = defaultMain
+  [ bgroup "initial algebra"
+    [ bench "1"  . nfIO $ replicateNodeInitial 1
+    , bench "100"  . nfIO $ replicateNodeInitial 100
+    , bench "1000"  . nfIO $ replicateNodeInitial 1000
+    ]
+  , bgroup "final algebra"
+    [ bench "1"  . nfIO $ replicateNodeFinal 1
+    , bench "100"  . nfIO $ replicateNodeFinal 100
+    , bench "1000"  . nfIO $ replicateNodeFinal 1000
+    ]
+  ]
+
+data A
+  = A
+  { aa :: String
+  , ab :: Int
+  } deriving (Generic)
+
+instance Arbitrary A where
+  arbitrary = A <$> arbitrary <*> arbitrary
+
+instance HasDependencies A
+
+graphIdentity :: Frontend NoConstraint Identity (IO r) -> IO r
+graphIdentity f = case f of
+  Insert n next ->
+    next $ Just $ Identity n
+  Remove _ next ->
+    next
+
+replicateNodeInitial :: Int -> IO ()
+replicateNodeInitial i = void . runGraphula graphIdentity . replicateM i $ node @A
+
+newtype TagglessGraphula a = TagglessGraphula { runTagglessGraphula :: IO a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow)
+
+instance MonadGraphulaFrontend TagglessGraphula where
+  type NodeConstraint TagglessGraphula = NoConstraint
+  type Entity TagglessGraphula = Identity
+  insert = pure . Just . Identity
+  removeM = const (pure ())
+
+instance MonadGraphulaBackend TagglessGraphula where
+  type Logging TagglessGraphula = NoConstraint
+  type Generate TagglessGraphula = Arbitrary
+  generateNode = liftIO $ generate arbitrary
+  logNode _ = pure ()
+
+replicateNodeFinal :: Int -> IO ()
+replicateNodeFinal i = void . runTagglessGraphula . replicateM i $ node @A

--- a/graphula-core/package.yaml
+++ b/graphula-core/package.yaml
@@ -34,3 +34,13 @@ tests:
       - graphula-core
       - hspec
       - markdown-unlit
+
+benchmarks:
+  bench:
+    source-dirs:
+      - bench
+    main: Main.hs
+    ghc-options: -Wall -O2
+    dependencies:
+      - criterion
+      - graphula-core

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -346,14 +346,14 @@ instance Exception GenerationFailure
 
 type GraphulaContext m a =
   ( Monad m
+  , MonadGraphulaBackend m
+  , MonadGraphulaFrontend m
+  , MonadThrow m
+  , Generate m a
+  , HasDependencies a
+  , Logging m a
   , NodeConstraint m a
   , Typeable a
-  , Generate m a
-  , Logging m a
-  , HasDependencies a
-  , MonadGraphulaFrontend m
-  , MonadGraphulaBackend m
-  , MonadThrow m
   )
 
 {-|

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -49,15 +49,15 @@ module Graphula
   -- * The Graph Monad
   , MonadGraphulaFrontend(..)
   , MonadGraphulaBackend(..)
-  , GraphulaT
   , runGraphulaT
-  , GraphulaLoggedT
+  , GraphulaT
   , runGraphulaLoggedT
   , runGraphulaLoggedWithFileT
-  , GraphulaReplayT
+  , GraphulaLoggedT
   , runGraphulaReplayT
-  , GraphulaIdempotentT
+  , GraphulaReplayT
   , runGraphulaIdempotentT
+  , GraphulaIdempotentT
   -- * Extras
   , NoConstraint
   -- * Exceptions
@@ -111,8 +111,10 @@ class MonadGraphulaBackend m where
   generateNode :: Generate m a => m a
   logNode :: Logging m a => a -> m ()
 
--- | Run a graphu utilizing 'Arbitrary' for node generation.
-newtype GraphulaT m a = GraphulaT {runGraphulaT :: m a}
+newtype GraphulaT m a = GraphulaT
+  { runGraphulaT :: m a
+  -- ^ Run a graphu utilizing 'Arbitrary' for node generation.
+  }
   deriving (Functor, Applicative, Monad, MonadThrow, MonadIO)
 
 instance MonadTrans GraphulaT where

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -125,7 +125,7 @@ class MonadGraphulaBackend m where
 
 newtype GraphulaT m a = GraphulaT
   { runGraphulaT :: m a
-  -- ^ Run a graphu utilizing 'Arbitrary' for node generation.
+  -- ^ Run a graph utilizing 'Arbitrary' for node generation.
   }
   deriving (Functor, Applicative, Monad, MonadThrow, MonadIO)
 

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -45,17 +45,7 @@ module Graphula
   , Only(..)
   , only
   -- * The Graph Monad
-  , Graph
-  , runGraphula
-  , runGraphulaLogged
-  , runGraphulaLoggedWithFile
-  , runGraphulaReplay
-  , runGraphulaIdempotent
-  , runGraphulaIdempotentLogged
-  -- * Graph Implementation
-  , Frontend(..)
   , MonadGraphulaFrontend(..)
-  , Backend(..)
   , MonadGraphulaBackend(..)
   -- * Extras
   , NoConstraint
@@ -72,10 +62,7 @@ import Control.Monad.Trans.Free (FreeT, iterT, liftF, transFreeT)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Exception (Exception, SomeException)
 import Data.Aeson (ToJSON, FromJSON, Value, Result(..), toJSON, fromJSON, encode, eitherDecodeStrict')
-import Data.ByteString (readFile)
-import Data.ByteString.Lazy (hPutStr)
 import Data.Foldable (for_)
-import Data.Functor.Sum (Sum(..))
 import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef')
 import Data.Proxy (Proxy(..))
 import Data.Sequence (Seq, ViewL(..), viewl, empty, (|>))
@@ -89,265 +76,27 @@ import System.Directory (getTemporaryDirectory)
 
 import Graphula.Internal
 
--- | 'Graph' is a type alias for graphula's underlying monad. This type carries
--- constraints via 'ConstraintKinds', which enable pluggable frontends and backends.
---
--- * __generate__: A constraint for pluggable node generation. 'runGraphula'
---   utilizes 'Arbitrary', 'runGraphulaReplay' utilizes 'FromJSON'.
--- * __log__: A constraint provided to log details of the graph to some form of
---   persistence. This is used by 'runGraphulaLogged' to store graph nodes as
---   JSON 'Value's.
--- * __nodeConstraint__: A constraint applied to nodes. This is utilized during
---   insertion and can be leveraged by frontends with typeclass interfaces
---   to insertion.
--- * __entity__: A wrapper type used to return relevant information about a given
---   node. `graphula-persistent` returns all nodes in the 'Entity' type.
-type Graph generate log nodeConstraint entity
-  = FreeT (Sum (Backend generate log) (Frontend nodeConstraint entity))
-
 class MonadGraphulaFrontend m where
   type NodeConstraint m :: * -> Constraint
-  type Entity m :: * -> *
-  insert :: (Monad m, NodeConstraint m a) => a -> m (Maybe (Entity m a))
-  remove :: (Monad m, NodeConstraint m a) => Entity m a -> m ()
-
-instance Monad m => MonadGraphulaFrontend (Graph generate log nodeConstraint entity m) where
-  type NodeConstraint (Graph generate log nodeConstraint entity m) = nodeConstraint
-  type Entity (Graph generate log nodeConstraint entity m) = entity
-  insert = liftRight . insert
-  remove = liftRight . remove
-
-instance Monad m => MonadGraphulaFrontend (FreeT (Frontend nodeConstraint entity) m) where
-  type NodeConstraint (FreeT (Frontend nodeConstraint entity) m) = nodeConstraint
-  type Entity (FreeT (Frontend nodeConstraint entity) m) = entity
-  insert n = liftF (Insert n id)
-  remove n = liftF (Remove n ())
+  -- ^ A constraint applied to nodes. This is utilized during
+  --   insertion and can be leveraged by frontends with typeclass interfaces
+  --   to insertion.
+  type Node m :: * -> *
+  -- ^ A wrapper type used to return relevant information about a given
+  --   node. `graphula-persistent` returns all nodes in the 'Database.Persist.Entity' type.
+  insert :: (Monad m, NodeConstraint m a) => a -> m (Maybe (Node m a))
+  remove :: (Monad m, NodeConstraint m a) => Node m a -> m ()
 
 class MonadGraphulaBackend m where
   type Logging m :: * -> Constraint
+  -- ^ A constraint provided to log details of the graph to some form of
+  --   persistence. This is used by 'runGraphulaLogged' to store graph nodes as
+  --   JSON 'Value's.
   type Generate m :: * -> Constraint
+  -- ^ A constraint for pluggable node generation. 'runGraphula'
+  --   utilizes 'Arbitrary', 'runGraphulaReplay' utilizes 'FromJSON'.
   generateNode :: Generate m a => m a
   logNode :: Logging m a => a -> m ()
-
-instance Monad m => MonadGraphulaBackend (Graph generate log nodeConstraint entity m) where
-  type Logging (Graph generate log nodeConstraint entity m) = log
-  type Generate (Graph generate log nodeConstraint entity m) = generate
-  generateNode = liftLeft . liftF $ GenerateNode id
-  logNode a = liftLeft . liftF $ LogNode a (const ())
-
-runGraphulaUsing
-  :: (MonadIO m, MonadCatch m)
-  => (Backend generate log (m a) -> m a)
-  -> (Frontend nodeConstraint entity (m a) -> m a)
-  -> Graph generate log nodeConstraint entity m a
-  -> m a
-runGraphulaUsing backend frontend f =
-  flip iterT f $ \case
-    InR r -> frontend r
-    InL l -> backend l
-
--- | Interpret a 'Graph' with a given 'Frontend' interpreter, utilizing
--- 'Arbitrary' for node generation.
-runGraphula
-  :: (MonadIO m, MonadCatch m)
-  => (Frontend nodeConstraint entity (m a) -> m a)
-  -> Graph Arbitrary NoConstraint nodeConstraint entity m a
-  -> m a
-runGraphula = runGraphulaUsing backendArbitrary
-
--- | An extension of 'runGraphula' that produces finalizers to remove graph nodes
--- on error or completion. An idempotent 'Graph' produces no data outside of its
--- own closure.
-runGraphulaIdempotent
-  :: (MonadIO m, MonadCatch m, MonadMask m)
-  => (Frontend nodeConstraint entity (m a) -> m a)
-  -> Graph Arbitrary NoConstraint nodeConstraint entity m a -> m a
-runGraphulaIdempotent = runGraphulaIdempotentUsing backendArbitrary
-
--- | An extension of 'runGraphulaIdemptotent' that produces replayable logs, like
--- 'runGraphulaLogged'.
-runGraphulaIdempotentLogged
-  :: (MonadIO m, MonadCatch m, MonadMask m)
-  => (Frontend nodeConstraint entity (m a) -> m a)
-  -> Graph Arbitrary ToJSON nodeConstraint entity m a -> m a
-runGraphulaIdempotentLogged frontend graph = do
-  graphLog <- liftIO $ newIORef empty
-  go graphLog `catch` logFailTemp graphLog
-  where
-    go graphLog = runGraphulaIdempotentUsing (backendArbitraryLogged graphLog) frontend graph
-
-runGraphulaIdempotentUsing
-  :: (MonadIO m, MonadCatch m, MonadMask m)
-  => (Backend generate log (m a) -> m a)
-  -> (Frontend nodeConstraint entity (m a) -> m a)
-  -> Graph generate log nodeConstraint entity m a -> m a
-runGraphulaIdempotentUsing backend frontend f =
-  mask $ \unmasked -> do
-    finalizersRef <- liftIO . newIORef $ pure ()
-    x <- unmasked $ interpret finalizersRef `catch` rollbackRethrow finalizersRef
-    rollback finalizersRef $ pure x
-  where
-    interpret finalizersRef =
-      runGraphulaUsing backend (iterT frontend . finalizerFrontend finalizersRef) f
-    rollback finalizersRef x = do
-      finalizers <- liftIO $ readIORef finalizersRef
-      iterT frontend (finalizers >> x)
-    rollbackRethrow finalizersRef (e :: SomeException) =
-      rollback finalizersRef (throwM e)
-
--- | An extension of 'runGraphula' that logs all json 'Value's to a temporary
--- file on 'Exception' and re-throws the 'Exception'.
-runGraphulaLogged
-  :: (MonadIO m, MonadCatch m)
-  => (Frontend nodeConstraint entity (m a) -> m a)
-  -> Graph Arbitrary ToJSON nodeConstraint entity m a
-  -> m a
-runGraphulaLogged =
-  runGraphulaLoggedUsing logFailTemp
-
--- | A variant of 'runGraphulaLogged' that accepts a file path to logged to
--- instead of utilizing a temp file.
-runGraphulaLoggedWithFile
-  :: (MonadIO m, MonadCatch m)
-  => FilePath
-  -> (Frontend nodeConstraint entity (m a) -> m a)
-  -> Graph Arbitrary ToJSON nodeConstraint entity m a
-  -> m a
-runGraphulaLoggedWithFile logPath =
-  runGraphulaLoggedUsing (logFailFile logPath)
-
-runGraphulaLoggedUsing
-  :: (MonadIO m, MonadCatch m)
-  => (IORef (Seq Value) -> HUnitFailure -> m a)
-  -> (Frontend nodeConstraint entity (m a) -> m a)
-  -> Graph Arbitrary ToJSON nodeConstraint entity m a
-  -> m a
-runGraphulaLoggedUsing logFail frontend f = do
-  graphLog <- liftIO $ newIORef empty
-  runGraphulaUsing (backendArbitraryLogged graphLog) frontend f
-    `catch` logFail graphLog
-
--- | Interpret a 'Graph' with a given 'Frontend' interpreter, utilizing a JSON
--- file for node generation via 'FromJSON'.
-runGraphulaReplay
-  :: (MonadIO m, MonadCatch m)
-  => FilePath
-  -> (Frontend nodeConstraint entity (m a) -> m a)
-  -> Graph FromJSON NoConstraint nodeConstraint entity m a -> m a
-runGraphulaReplay replayFile frontend f = do
-  replayLog <-
-    liftIO $ do
-      bytes <- readFile replayFile
-      case eitherDecodeStrict' bytes of
-        Left err -> throwM $ userError err
-        Right nodes -> newIORef nodes
-  runGraphulaUsing (backendReplay replayLog) frontend f
-    `catch` rethrowHUnitReplay replayFile
-
-
-finalizerFrontend
-  :: (MonadThrow m, MonadIO m)
-  => IORef (FreeT (Frontend nodeConstraint entity) m ())
-  -> Frontend nodeConstraint entity (m a)
-  -> FreeT (Frontend nodeConstraint entity) m a
-finalizerFrontend finalizersRef f = case f of
-  Insert n next -> do
-    mEnt <- liftF $ Insert n id
-    for_ mEnt $ \ent ->
-      liftIO $ modifyIORef' finalizersRef (remove ent >>)
-    lift $ next mEnt
-  Remove ent next -> do
-    remove ent
-    lift next
-
-backendArbitrary :: (MonadThrow m, MonadIO m) => Backend Arbitrary NoConstraint (m b) -> m b
-backendArbitrary = \case
-  GenerateNode next -> do
-    a <- liftIO . generate $ arbitrary
-    next a
-  LogNode _ next -> next ()
-
-backendArbitraryLogged :: (MonadThrow m, MonadIO m) => IORef (Seq Value) -> Backend Arbitrary ToJSON (m b) -> m b
-backendArbitraryLogged graphLog = \case
-  GenerateNode next -> do
-    a <- liftIO . generate $ arbitrary
-    next a
-  LogNode a next -> do
-    liftIO $ modifyIORef' graphLog (|> toJSON a)
-    next ()
-
-backendReplay :: (MonadThrow m, MonadIO m) => IORef (Seq Value) -> Backend FromJSON NoConstraint (m b) -> m b
-backendReplay replayRef = \case
-  GenerateNode next -> do
-    mJsonNode <- popReplay replayRef
-    case mJsonNode of
-      Nothing -> throwM $ userError "Not enough replay data to fullfill graph."
-      Just jsonNode ->
-        case fromJSON jsonNode of
-          Error err -> throwM $ userError err
-          Success a -> next a
-  LogNode _ next -> next ()
-
-popReplay :: MonadIO m => IORef (Seq Value) -> m (Maybe Value)
-popReplay ref = liftIO $ do
-  nodes <- readIORef ref
-  case viewl nodes of
-    EmptyL -> pure Nothing
-    n :< ns -> do
-      writeIORef ref ns
-      pure $ Just n
-
-logFailUsing :: (MonadIO m, MonadThrow m) => IO (FilePath, Handle) -> IORef (Seq Value) -> HUnitFailure -> m a
-logFailUsing f graphLog hunitfailure =
-  flip rethrowHUnitLogged hunitfailure =<< logGraphToHandle graphLog f
-
-logFailFile :: (MonadIO m, MonadThrow m) => FilePath -> IORef (Seq Value) -> HUnitFailure -> m a
-logFailFile path =
-  logFailUsing ((path, ) <$> openFile path WriteMode)
-
-logFailTemp :: (MonadIO m, MonadThrow m) => IORef (Seq Value) -> HUnitFailure -> m a
-logFailTemp =
-  logFailUsing (flip openTempFile "fail-.graphula" =<< getTemporaryDirectory)
-
-logGraphToHandle :: (MonadIO m) => IORef (Seq Value) -> IO (FilePath, Handle) -> m FilePath
-logGraphToHandle graphLog openHandle =
-  liftIO $ bracket
-    openHandle
-    (hClose . snd)
-    (\(path, handle) -> readIORef graphLog >>= hPutStr handle . encode >> pure path )
-
-
-rethrowHUnitWith :: MonadThrow m => String -> HUnitFailure -> m a
-rethrowHUnitWith message (HUnitFailure l r)  =
-  throwM . HUnitFailure l . Reason $ message ++ "\n\n" ++ formatFailureReason r
-
-rethrowHUnitLogged :: MonadThrow m => FilePath -> HUnitFailure -> m a
-rethrowHUnitLogged path  =
-  rethrowHUnitWith ("Graph dumped in temp file: " ++ path)
-
-rethrowHUnitReplay :: (MonadIO m, MonadThrow m) => FilePath -> HUnitFailure -> m a
-rethrowHUnitReplay filePath =
-  rethrowHUnitWith ("Using graph file: " ++ filePath)
-
-
-liftLeft :: (Monad m, Functor f, Functor g) => FreeT f m a -> FreeT (Sum f g) m a
-liftLeft = transFreeT InL
-
-liftRight :: (Monad m, Functor f, Functor g) => FreeT g m a -> FreeT (Sum f g) m a
-liftRight = transFreeT InR
-
-
-data Frontend (nodeConstraint :: * -> Constraint) entity next where
-  Insert :: nodeConstraint a => a -> (Maybe (entity a) -> next) -> Frontend nodeConstraint entity next
-  Remove :: nodeConstraint a => entity a -> next -> Frontend nodeConstraint entity next
-
-deriving instance Functor (Frontend nodeConstraint entity)
-
-data Backend (generate :: * -> Constraint) (log :: * -> Constraint) next where
-  GenerateNode :: (generate a) => (a -> next) -> Backend generate log next
-  LogNode :: (log a) => a -> (() -> next) -> Backend generate log next
-
-deriving instance Functor (Backend generate log)
 
 -- | `Graph` accepts constraints for various uses. Frontends do not always
 -- utilize these constraints. 'NoConstraint' is a universal class that all
@@ -415,7 +164,7 @@ nodeEditWith
      , MonadGraphulaBackend m
      , MonadThrow m
      )
-  => Dependencies a -> (a -> a) -> m (Entity m a)
+  => Dependencies a -> (a -> a) -> m (Node m a)
 nodeEditWith dependencies edits =
   10 `attemptsToInsertWith` do
     x <- (`dependsOn` dependencies) . edits <$> generateNode
@@ -440,7 +189,7 @@ nodeWith
      , MonadGraphulaBackend m
      , MonadThrow m
      )
-  => Dependencies a -> m (Entity m a)
+  => Dependencies a -> m (Node m a)
 nodeWith = flip nodeEditWith id
 
 {-|
@@ -461,7 +210,7 @@ nodeEdit
      , MonadGraphulaBackend m
      , MonadThrow m
      )
-  => (a -> a) -> m (Entity m a)
+  => (a -> a) -> m (Node m a)
 nodeEdit = nodeEditWith ()
 
 -- | Generate a value that does not have any dependencies
@@ -480,7 +229,7 @@ node
      , MonadGraphulaBackend m
      , MonadThrow m
      )
-  => m (Entity m a)
+  => m (Node m a)
 node = nodeWith ()
 
 attemptsToInsertWith
@@ -494,7 +243,7 @@ attemptsToInsertWith
       )
   => Int
   -> m a
-  -> m (Entity m a)
+  -> m (Node m a)
 attemptsToInsertWith attempts source
   | 0 >= attempts =
       throwM . GenerationFailureMaxAttempts $ typeRep (Proxy :: Proxy a)

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -109,19 +109,19 @@ class MonadGraphulaFrontend m where
   type NodeConstraint m :: * -> Constraint
   type Entity m :: * -> *
   insert :: (Monad m, NodeConstraint m a) => a -> m (Maybe (Entity m a))
-  removeM :: (Monad m, NodeConstraint m a) => Entity m a -> m ()
+  remove :: (Monad m, NodeConstraint m a) => Entity m a -> m ()
 
 instance Monad m => MonadGraphulaFrontend (Graph generate log nodeConstraint entity m) where
   type NodeConstraint (Graph generate log nodeConstraint entity m) = nodeConstraint
   type Entity (Graph generate log nodeConstraint entity m) = entity
   insert = liftRight . insert
-  removeM = liftRight . removeM
+  remove = liftRight . remove
 
 instance Monad m => MonadGraphulaFrontend (FreeT (Frontend nodeConstraint entity) m) where
   type NodeConstraint (FreeT (Frontend nodeConstraint entity) m) = nodeConstraint
   type Entity (FreeT (Frontend nodeConstraint entity) m) = entity
   insert n = liftF (Insert n id)
-  removeM n = liftF (Remove n ())
+  remove n = liftF (Remove n ())
 
 class MonadGraphulaBackend m where
   type Logging m :: * -> Constraint
@@ -342,9 +342,6 @@ data Frontend (nodeConstraint :: * -> Constraint) entity next where
   Remove :: nodeConstraint a => entity a -> next -> Frontend nodeConstraint entity next
 
 deriving instance Functor (Frontend nodeConstraint entity)
-
-remove :: (Monad m, nodeConstraint a) => entity a -> FreeT (Frontend nodeConstraint entity) m ()
-remove n = liftF (Remove n ())
 
 data Backend (generate :: * -> Constraint) (log :: * -> Constraint) next where
   GenerateNode :: (generate a) => (a -> next) -> Backend generate log next

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -48,10 +48,14 @@ module Graphula
   -- * The Graph Monad
   , MonadGraphulaFrontend(..)
   , MonadGraphulaBackend(..)
+  , GraphulaT
   , runGraphulaT
+  , GraphulaLoggedT
   , runGraphulaLoggedT
   , runGraphulaLoggedWithFileT
+  , GraphulaReplayT
   , runGraphulaReplayT
+  , GraphulaIdempotentT
   , runGraphulaIdempotentT
   -- * Extras
   , NoConstraint

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -97,8 +97,8 @@ class MonadGraphulaFrontend m where
   type Node m :: * -> *
   -- ^ A wrapper type used to return relevant information about a given
   --   node. `graphula-persistent` returns all nodes in the 'Database.Persist.Entity' type.
-  insert :: (Monad m, NodeConstraint m a) => a -> m (Maybe (Node m a))
-  remove :: (Monad m, NodeConstraint m a) => Node m a -> m ()
+  insert :: NodeConstraint m a => a -> m (Maybe (Node m a))
+  remove :: NodeConstraint m a => Node m a -> m ()
 
 class MonadGraphulaBackend m where
   type Logging m :: * -> Constraint

--- a/graphula-core/src/Graphula/Free.hs
+++ b/graphula-core/src/Graphula/Free.hs
@@ -1,0 +1,318 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ConstrainedClassMethods #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TupleSections #-}
+
+module Graphula.Free
+  ( -- * Graph Declaration
+    node
+  , nodeEdit
+  , nodeWith
+  , nodeEditWith
+  -- * Declaring Dependencies
+  , HasDependencies(..)
+  -- ** Singular Dependencies
+  , Only(..)
+  , only
+  -- * The Graph Monad
+  , Graph
+  , runGraphula
+  , runGraphulaLogged
+  , runGraphulaLoggedWithFile
+  , runGraphulaReplay
+  , runGraphulaIdempotent
+  , runGraphulaIdempotentLogged
+  -- * Graph Implementation
+  , Frontend(..)
+  , MonadGraphulaFrontend(..)
+  , Backend(..)
+  , MonadGraphulaBackend(..)
+  -- * Extras
+  , NoConstraint
+  -- * Exceptions
+  , GenerationFailure(..)
+  ) where
+
+import Prelude hiding (readFile, lines)
+import Test.QuickCheck (Arbitrary(..), generate)
+import Test.HUnit.Lang (HUnitFailure(..), FailureReason(..), formatFailureReason)
+import Control.Monad.Catch (MonadCatch(..), MonadThrow(..), MonadMask(..), bracket)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Free (FreeT, iterT, liftF, transFreeT)
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Exception (SomeException)
+import Data.Aeson (ToJSON, FromJSON, Value, Result(..), toJSON, fromJSON, encode, eitherDecodeStrict')
+import Data.ByteString (readFile)
+import Data.ByteString.Lazy (hPutStr)
+import Data.Foldable (for_)
+import Data.Functor.Sum (Sum(..))
+import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef')
+import Data.Sequence (Seq, ViewL(..), viewl, empty, (|>))
+import GHC.Exts (Constraint)
+import System.IO (hClose, openFile, IOMode(..), Handle)
+import System.IO.Temp (openTempFile)
+import System.Directory (getTemporaryDirectory)
+
+import Graphula
+
+
+-- | 'Graph' is a type alias for graphula's underlying monad. This type carries
+-- constraints via 'ConstraintKinds', which enable pluggable frontends and backends.
+--
+-- * __generate__: A constraint for pluggable node generation. 'runGraphula'
+--   utilizes 'Arbitrary', 'runGraphulaReplay' utilizes 'FromJSON'.
+-- * __log__: A constraint provided to log details of the graph to some form of
+--   persistence. This is used by 'runGraphulaLogged' to store graph nodes as
+--   JSON 'Value's.
+-- * __nodeConstraint__: A constraint applied to nodes. This is utilized during
+--   insertion and can be leveraged by frontends with typeclass interfaces
+--   to insertion.
+-- * __entity__: A wrapper type used to return relevant information about a given
+--   node. `graphula-persistent` returns all nodes in the 'Entity' type.
+type Graph generate log nodeConstraint entity
+  = FreeT (Sum (Backend generate log) (Frontend nodeConstraint entity))
+
+instance Monad m => MonadGraphulaFrontend (Graph generate log nodeConstraint entity m) where
+  type NodeConstraint (Graph generate log nodeConstraint entity m) = nodeConstraint
+  type Node (Graph generate log nodeConstraint entity m) = entity
+  insert = liftRight . insert
+  remove = liftRight . remove
+
+instance Monad m => MonadGraphulaFrontend (FreeT (Frontend nodeConstraint entity) m) where
+  type NodeConstraint (FreeT (Frontend nodeConstraint entity) m) = nodeConstraint
+  type Node (FreeT (Frontend nodeConstraint entity) m) = entity
+  insert n = liftF (Insert n id)
+  remove n = liftF (Remove n ())
+
+instance Monad m => MonadGraphulaBackend (Graph generate log nodeConstraint entity m) where
+  type Logging (Graph generate log nodeConstraint entity m) = log
+  type Generate (Graph generate log nodeConstraint entity m) = generate
+  generateNode = liftLeft . liftF $ GenerateNode id
+  logNode a = liftLeft . liftF $ LogNode a (const ())
+
+
+liftLeft :: (Monad m, Functor f, Functor g) => FreeT f m a -> FreeT (Sum f g) m a
+liftLeft = transFreeT InL
+
+liftRight :: (Monad m, Functor f, Functor g) => FreeT g m a -> FreeT (Sum f g) m a
+liftRight = transFreeT InR
+
+
+data Frontend (nodeConstraint :: * -> Constraint) entity next where
+  Insert :: nodeConstraint a => a -> (Maybe (entity a) -> next) -> Frontend nodeConstraint entity next
+  Remove :: nodeConstraint a => entity a -> next -> Frontend nodeConstraint entity next
+
+deriving instance Functor (Frontend nodeConstraint entity)
+
+data Backend (generate :: * -> Constraint) (log :: * -> Constraint) next where
+  GenerateNode :: (generate a) => (a -> next) -> Backend generate log next
+  LogNode :: (log a) => a -> (() -> next) -> Backend generate log next
+
+deriving instance Functor (Backend generate log)
+
+runGraphulaUsing
+  :: (MonadIO m, MonadCatch m)
+  => (Backend generate log (m a) -> m a)
+  -> (Frontend nodeConstraint entity (m a) -> m a)
+  -> Graph generate log nodeConstraint entity m a
+  -> m a
+runGraphulaUsing backend frontend f =
+  flip iterT f $ \case
+    InR r -> frontend r
+    InL l -> backend l
+
+-- | Interpret a 'Graph' with a given 'Frontend' interpreter, utilizing
+-- 'Arbitrary' for node generation.
+runGraphula
+  :: (MonadIO m, MonadCatch m)
+  => (Frontend nodeConstraint entity (m a) -> m a)
+  -> Graph Arbitrary NoConstraint nodeConstraint entity m a
+  -> m a
+runGraphula = runGraphulaUsing backendArbitrary
+
+-- | An extension of 'runGraphula' that produces finalizers to remove graph nodes
+-- on error or completion. An idempotent 'Graph' produces no data outside of its
+-- own closure.
+runGraphulaIdempotent
+  :: (MonadIO m, MonadCatch m, MonadMask m)
+  => (Frontend nodeConstraint entity (m a) -> m a)
+  -> Graph Arbitrary NoConstraint nodeConstraint entity m a -> m a
+runGraphulaIdempotent = runGraphulaIdempotentUsing backendArbitrary
+
+-- | An extension of 'runGraphulaIdemptotent' that produces replayable logs, like
+-- 'runGraphulaLogged'.
+runGraphulaIdempotentLogged
+  :: (MonadIO m, MonadCatch m, MonadMask m)
+  => (Frontend nodeConstraint entity (m a) -> m a)
+  -> Graph Arbitrary ToJSON nodeConstraint entity m a -> m a
+runGraphulaIdempotentLogged frontend graph = do
+  graphLog <- liftIO $ newIORef empty
+  go graphLog `catch` logFailTemp graphLog
+  where
+    go graphLog = runGraphulaIdempotentUsing (backendArbitraryLogged graphLog) frontend graph
+
+runGraphulaIdempotentUsing
+  :: (MonadIO m, MonadCatch m, MonadMask m)
+  => (Backend generate log (m a) -> m a)
+  -> (Frontend nodeConstraint entity (m a) -> m a)
+  -> Graph generate log nodeConstraint entity m a -> m a
+runGraphulaIdempotentUsing backend frontend f =
+  mask $ \unmasked -> do
+    finalizersRef <- liftIO . newIORef $ pure ()
+    x <- unmasked $ interpret finalizersRef `catch` rollbackRethrow finalizersRef
+    rollback finalizersRef $ pure x
+  where
+    interpret finalizersRef =
+      runGraphulaUsing backend (iterT frontend . finalizerFrontend finalizersRef) f
+    rollback finalizersRef x = do
+      finalizers <- liftIO $ readIORef finalizersRef
+      iterT frontend (finalizers >> x)
+    rollbackRethrow finalizersRef (e :: SomeException) =
+      rollback finalizersRef (throwM e)
+
+-- | An extension of 'runGraphula' that logs all json 'Value's to a temporary
+-- file on 'Exception' and re-throws the 'Exception'.
+runGraphulaLogged
+  :: (MonadIO m, MonadCatch m)
+  => (Frontend nodeConstraint entity (m a) -> m a)
+  -> Graph Arbitrary ToJSON nodeConstraint entity m a
+  -> m a
+runGraphulaLogged =
+  runGraphulaLoggedUsing logFailTemp
+
+-- | A variant of 'runGraphulaLogged' that accepts a file path to logged to
+-- instead of utilizing a temp file.
+runGraphulaLoggedWithFile
+  :: (MonadIO m, MonadCatch m)
+  => FilePath
+  -> (Frontend nodeConstraint entity (m a) -> m a)
+  -> Graph Arbitrary ToJSON nodeConstraint entity m a
+  -> m a
+runGraphulaLoggedWithFile logPath =
+  runGraphulaLoggedUsing (logFailFile logPath)
+
+runGraphulaLoggedUsing
+  :: (MonadIO m, MonadCatch m)
+  => (IORef (Seq Value) -> HUnitFailure -> m a)
+  -> (Frontend nodeConstraint entity (m a) -> m a)
+  -> Graph Arbitrary ToJSON nodeConstraint entity m a
+  -> m a
+runGraphulaLoggedUsing logFail frontend f = do
+  graphLog <- liftIO $ newIORef empty
+  runGraphulaUsing (backendArbitraryLogged graphLog) frontend f
+    `catch` logFail graphLog
+
+-- | Interpret a 'Graph' with a given 'Frontend' interpreter, utilizing a JSON
+-- file for node generation via 'FromJSON'.
+runGraphulaReplay
+  :: (MonadIO m, MonadCatch m)
+  => FilePath
+  -> (Frontend nodeConstraint entity (m a) -> m a)
+  -> Graph FromJSON NoConstraint nodeConstraint entity m a -> m a
+runGraphulaReplay replayFile frontend f = do
+  replayLog <-
+    liftIO $ do
+      bytes <- readFile replayFile
+      case eitherDecodeStrict' bytes of
+        Left err -> throwM $ userError err
+        Right nodes -> newIORef nodes
+  runGraphulaUsing (backendReplay replayLog) frontend f
+    `catch` rethrowHUnitReplay replayFile
+
+
+finalizerFrontend
+  :: (MonadThrow m, MonadIO m)
+  => IORef (FreeT (Frontend nodeConstraint entity) m ())
+  -> Frontend nodeConstraint entity (m a)
+  -> FreeT (Frontend nodeConstraint entity) m a
+finalizerFrontend finalizersRef f = case f of
+  Insert n next -> do
+    mEnt <- liftF $ Insert n id
+    for_ mEnt $ \ent ->
+      liftIO $ modifyIORef' finalizersRef (remove ent >>)
+    lift $ next mEnt
+  Remove ent next -> do
+    remove ent
+    lift next
+
+backendArbitrary :: (MonadThrow m, MonadIO m) => Backend Arbitrary NoConstraint (m b) -> m b
+backendArbitrary = \case
+  GenerateNode next -> do
+    a <- liftIO . generate $ arbitrary
+    next a
+  LogNode _ next -> next ()
+
+backendArbitraryLogged :: (MonadThrow m, MonadIO m) => IORef (Seq Value) -> Backend Arbitrary ToJSON (m b) -> m b
+backendArbitraryLogged graphLog = \case
+  GenerateNode next -> do
+    a <- liftIO . generate $ arbitrary
+    next a
+  LogNode a next -> do
+    liftIO $ modifyIORef' graphLog (|> toJSON a)
+    next ()
+
+backendReplay :: (MonadThrow m, MonadIO m) => IORef (Seq Value) -> Backend FromJSON NoConstraint (m b) -> m b
+backendReplay replayRef = \case
+  GenerateNode next -> do
+    mJsonNode <- popReplay replayRef
+    case mJsonNode of
+      Nothing -> throwM $ userError "Not enough replay data to fullfill graph."
+      Just jsonNode ->
+        case fromJSON jsonNode of
+          Error err -> throwM $ userError err
+          Success a -> next a
+  LogNode _ next -> next ()
+
+popReplay :: MonadIO m => IORef (Seq Value) -> m (Maybe Value)
+popReplay ref = liftIO $ do
+  nodes <- readIORef ref
+  case viewl nodes of
+    EmptyL -> pure Nothing
+    n :< ns -> do
+      writeIORef ref ns
+      pure $ Just n
+
+logFailUsing :: (MonadIO m, MonadThrow m) => IO (FilePath, Handle) -> IORef (Seq Value) -> HUnitFailure -> m a
+logFailUsing f graphLog hunitfailure =
+  flip rethrowHUnitLogged hunitfailure =<< logGraphToHandle graphLog f
+
+logFailFile :: (MonadIO m, MonadThrow m) => FilePath -> IORef (Seq Value) -> HUnitFailure -> m a
+logFailFile path =
+  logFailUsing ((path, ) <$> openFile path WriteMode)
+
+logFailTemp :: (MonadIO m, MonadThrow m) => IORef (Seq Value) -> HUnitFailure -> m a
+logFailTemp =
+  logFailUsing (flip openTempFile "fail-.graphula" =<< getTemporaryDirectory)
+
+logGraphToHandle :: (MonadIO m) => IORef (Seq Value) -> IO (FilePath, Handle) -> m FilePath
+logGraphToHandle graphLog openHandle =
+  liftIO $ bracket
+    openHandle
+    (hClose . snd)
+    (\(path, handle) -> readIORef graphLog >>= hPutStr handle . encode >> pure path )
+
+
+rethrowHUnitWith :: MonadThrow m => String -> HUnitFailure -> m a
+rethrowHUnitWith message (HUnitFailure l r)  =
+  throwM . HUnitFailure l . Reason $ message ++ "\n\n" ++ formatFailureReason r
+
+rethrowHUnitLogged :: MonadThrow m => FilePath -> HUnitFailure -> m a
+rethrowHUnitLogged path  =
+  rethrowHUnitWith ("Graph dumped in temp file: " ++ path)
+
+rethrowHUnitReplay :: (MonadIO m, MonadThrow m) => FilePath -> HUnitFailure -> m a
+rethrowHUnitReplay filePath =
+  rethrowHUnitWith ("Using graph file: " ++ filePath)

--- a/graphula-core/src/Graphula/Free.hs
+++ b/graphula-core/src/Graphula/Free.hs
@@ -66,7 +66,7 @@ import System.IO (hClose, openFile, IOMode(..), Handle)
 import System.IO.Temp (openTempFile)
 import System.Directory (getTemporaryDirectory)
 
-import Graphula
+import Graphula hiding (runGraphula)
 
 
 -- | 'Graph' is a type alias for graphula's underlying monad. This type carries

--- a/graphula-core/src/Graphula/Free.hs
+++ b/graphula-core/src/Graphula/Free.hs
@@ -66,7 +66,7 @@ import System.IO (hClose, openFile, IOMode(..), Handle)
 import System.IO.Temp (openTempFile)
 import System.Directory (getTemporaryDirectory)
 
-import Graphula hiding (runGraphula)
+import Graphula
 
 
 -- | 'Graph' is a type alias for graphula's underlying monad. This type carries

--- a/graphula-persistent/README.lhs
+++ b/graphula-persistent/README.lhs
@@ -21,6 +21,7 @@ import Database.Persist.Sqlite
 import Database.Persist.TH
 import GHC.Generics
 import Graphula
+import Graphula.Free
 import Graphula.Persist
 import Test.Hspec
 import Test.QuickCheck

--- a/graphula-persistent/README.lhs
+++ b/graphula-persistent/README.lhs
@@ -21,7 +21,6 @@ import Database.Persist.Sqlite
 import Database.Persist.TH
 import GHC.Generics
 import Graphula
-import Graphula.Free
 import Graphula.Persist
 import Test.Hspec
 import Test.QuickCheck
@@ -143,6 +142,6 @@ migrateTestDB = runMigration migrateAll
 runTestDB :: ReaderT SqlBackend (NoLoggingT (ResourceT IO)) a -> IO a
 runTestDB = runSqlite ":test:"
 
-withGraph :: Graph Arbitrary ToJSON (PersistRecord SqlBackend) Entity IO b -> IO b
-withGraph = runGraphulaIdempotentLogged (persistGraph runTestDB)
+withGraph :: GraphulaLoggedT (GraphulaIdempotentT (GraphulaPersistT SqlBackend (NoLoggingT (ResourceT IO)) IO)) b -> IO b
+withGraph = runGraphulaPersistT runTestDB . runGraphulaIdempotentT . runGraphulaLoggedT
 ```

--- a/graphula-persistent/package.yaml
+++ b/graphula-persistent/package.yaml
@@ -7,6 +7,7 @@ extra-source-files:
 
 dependencies:
   - base
+  - exceptions
   - graphula-core
   - mtl
   - persistent

--- a/graphula-persistent/src/Graphula/Persist.hs
+++ b/graphula-persistent/src/Graphula/Persist.hs
@@ -10,6 +10,7 @@
 module Graphula.Persist (persistGraph, onlyKey, keys, Keys, PersistRecord) where
 
 import Graphula
+import qualified Graphula.Free as Free
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Reader
 import Database.Persist
@@ -19,16 +20,16 @@ import GHC.TypeLits (TypeError, ErrorMessage(..))
 persistGraph
   :: (SqlBackendCanWrite backend, MonadIO m, MonadIO n)
   => (forall b. ReaderT backend n b -> m b)
-  -> Frontend (PersistRecord backend) Entity (m a) -> m a
+  -> Free.Frontend (PersistRecord backend) Entity (m a) -> m a
 persistGraph runDB = \case
-  Insert n next -> do
+  Free.Insert n next -> do
     x <- runDB $ do
       mKey <- insertUnique n
       case mKey of
         Nothing -> pure Nothing
         Just key' -> getEntity key'
     next x
-  Remove n next -> do
+  Free.Remove n next -> do
     runDB . delete $ entityKey n
     next
 


### PR DESCRIPTION
This commit introduces MonadGraphulaFrontend and MonadGraphulaBackend, the two demarcations of functionality in Graphula. We can likely split this even more, but it isn't necessary now.

Most graphula graphs are very small and this switch would likely not be necessary. However recently we've been experimenting with graphula for generating large sets of arbitrary test data for benchmarking etc. The free representation is extremely problematic in this situation.

With profiling and benchmarking we can see this

### Free
```
	total time  =       12.38 secs   (12382 ticks @ 1000 us, 1 processor)
	total alloc = 23,944,694,912 bytes  (excludes profiling overheads)

COST CENTRE        MODULE                            SRC                                                    %time %alloc

>>=.\              Control.Monad.Trans.Free          src/Control/Monad/Trans/Free.hs:(229,39)-(231,44)       21.1   27.2
>>=                Control.Monad.Trans.Free          src/Control/Monad/Trans/Free.hs:(229,3)-(231,44)        18.2   16.6
fmap               Graphula                          src/Graphula.hs:331:1-48                                11.9   20.1
getOverhead        Criterion.Monad                   Criterion/Monad.hs:(47,1)-(56,12)                        6.9    0.0
getGCStats         Criterion.Measurement             Criterion/Measurement.hs:(46,1)-(48,16)                  4.9    0.0
>>=                Data.Vector.Fusion.Util           Data/Vector/Fusion/Util.hs:33:3-18                       3.7    3.7
fmap               Graphula                          src/Graphula.hs:317:1-58                                 2.8    6.5
transFreeT         Control.Monad.Trans.Free          src/Control/Monad/Trans/Free.hs:337:1-79                 2.6    3.4
fmap               Control.Monad.Trans.Free          src/Control/Monad/Trans/Free.hs:(209,3)-(211,42)         2.4    2.6
fmap               Control.Monad.Trans.Free          src/Control/Monad/Trans/Free.hs:(132,3)-(133,37)         1.9    1.8
iterT              Control.Monad.Trans.Free          src/Control/Monad/Trans/Free.hs:(309,1)-(313,21)         1.6    1.4
basicUnsafeWrite   Data.Vector.Primitive.Mutable     Data/Vector/Primitive/Mutable.hs:114:3-69                1.5    0.7
fmap.f'            Control.Monad.Trans.Free          src/Control/Monad/Trans/Free.hs:(210,5)-(211,42)         1.2    1.7
basicUnsafeIndexM  Data.Vector.Primitive             Data/Vector/Primitive.hs:215:3-75                        1.0    1.0
backendArbitrary.\ Graphula                          src/Graphula.hs:(232,24)-(234,10)                        1.0    0.5
innerProduct.\     Statistics.Matrix.Algorithms      Statistics/Matrix/Algorithms.hs:42:3-51                  1.0    0.8
fmap               Data.Vector.Fusion.Stream.Monadic Data/Vector/Fusion/Stream/Monadic.hs:(125,3)-(127,20)    0.9    1.1
```

```
time                 7.636 μs   (7.332 μs .. 7.960 μs)
                     0.989 R²   (0.983 R² .. 0.996 R²)
mean                 7.578 μs   (7.383 μs .. 7.929 μs)
std dev              863.0 ns   (559.6 ns .. 1.460 μs)
variance introduced by outliers: 89% (severely inflated)
             
benchmarking initial algebra/100
time                 3.864 ms   (3.709 ms .. 4.046 ms)
                     0.991 R²   (0.987 R² .. 0.996 R²)
mean                 3.932 ms   (3.879 ms .. 3.999 ms)
std dev              196.6 μs   (158.3 μs .. 260.0 μs)
variance introduced by outliers: 30% (moderately inflated)
             
benchmarking initial algebra/1000
time                 371.4 ms   (346.2 ms .. 401.8 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 372.5 ms   (368.3 ms .. 376.2 ms)
std dev              5.980 ms   (0.0 s .. 6.390 ms)
variance introduced by outliers: 19% (moderately inflated)
```

### Tag-less
```
	total time  =       14.48 secs   (14483 ticks @ 1000 us, 1 processor)
	total alloc = 21,409,688,160 bytes  (excludes profiling overheads)

COST CENTRE            MODULE                            SRC                                                    %time %alloc

nodeEditWith           Graphula                          src/Graphula.hs:(422,1)-(426,10)                        16.6   15.9
replicateNodeFinal     Main                              bench/Main.hs:68:1-74                                   13.4   17.9
attemptsToInsertWith   Graphula                          src/Graphula.hs:(501,1)-(508,60)                        12.8   12.4
>>=                    Data.Vector.Fusion.Util           Data/Vector/Fusion/Util.hs:33:3-18                       6.3    8.2
insert                 Main                              bench/Main.hs:58:3-33                                    6.1    9.7
getOverhead            Criterion.Monad                   Criterion/Monad.hs:(47,1)-(56,12)                        5.9    0.0
getGCStats             Criterion.Measurement             Criterion/Measurement.hs:(46,1)-(48,16)                  4.1    0.0
newTFGen               System.Random.TF.Init             src/System/Random/TF/Init.hs:82:1-43                     2.7    8.8
attemptsToInsertWith.\ Graphula                          src/Graphula.hs:507:17-22                                2.4    3.5
basicUnsafeWrite       Data.Vector.Primitive.Mutable     Data/Vector/Primitive/Mutable.hs:114:3-69                2.1    1.5
generate               Test.QuickCheck.Gen               Test/QuickCheck/Gen.hs:(101,1)-(103,20)                  2.0    2.7
newQCGen               Test.QuickCheck.Random            Test/QuickCheck/Random.hs:80:1-31                        1.9    0.0
fmap                   Data.Vector.Fusion.Stream.Monadic Data/Vector/Fusion/Stream/Monadic.hs:(125,3)-(127,20)    1.8    2.3
logNode                Main                              bench/Main.hs:65:3-21                                    1.7    0.0
basicUnsafeIndexM      Data.Vector.Primitive             Data/Vector/Primitive.hs:215:3-75                        1.7    2.1
rSquare.p              Statistics.Regression             Statistics/Regression.hs:109:5-66                        1.6    1.6
innerProduct.\         Statistics.Matrix.Algorithms      Statistics/Matrix/Algorithms.hs:42:3-51                  1.5    1.7
kbnAdd                 Numeric.Sum                       Numeric/Sum.hs:(138,1)-(141,39)                          1.5    0.9
basicUnsafeIndexM      Data.Vector.Unboxed.Base          Data/Vector/Unboxed/Base.hs:283:841-899                  1.2    0.0
qr.\.\                 Statistics.Matrix.Algorithms      Statistics/Matrix/Algorithms.hs:29:34-51                 1.1    1.3
transpose              Statistics.Matrix                 Statistics/Matrix.hs:(268,1)-(270,22)                    0.9    1.3
basicUnsafeSlice       Data.Vector.Primitive.Mutable     Data/Vector/Primitive/Mutable.hs:(84,3)-(85,25)          0.6    1.2
```

```     
benchmarking final algebra/1
time                 694.9 ns   (588.1 ns .. 886.2 ns)
                     0.779 R²   (0.705 R² .. 0.994 R²)
mean                 711.0 ns   (626.1 ns .. 914.5 ns)
std dev              394.6 ns   (202.7 ns .. 661.0 ns)
variance introduced by outliers: 100% (severely inflated)
             
benchmarking final algebra/100
time                 55.56 μs   (51.88 μs .. 61.24 μs)
                     0.958 R²   (0.912 R² .. 0.998 R²)
mean                 53.21 μs   (51.88 μs .. 57.81 μs)
std dev              7.194 μs   (2.823 μs .. 14.14 μs)
variance introduced by outliers: 90% (severely inflated)
             
benchmarking final algebra/1000
time                 619.8 μs   (577.1 μs .. 658.1 μs)
                     0.979 R²   (0.971 R² .. 0.993 R²)
mean                 615.3 μs   (598.8 μs .. 634.3 μs)
std dev              63.55 μs   (50.65 μs .. 77.26 μs)
variance introduced by outliers: 76% (severely inflated)
```